### PR TITLE
feat: Implement Issue #239 - Long Press Quick Menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kasya",
-  "version": "1.0.6",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kasya",
-      "version": "1.0.6",
+      "version": "1.2.0",
       "dependencies": {
         "@capacitor/android": "^6.0.0",
         "@capacitor/app": "^6.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -514,6 +514,12 @@ const App: React.FC = () => {
         handleOpenModal('TX_FORM');
     };
 
+    const handleQuickAdd = (type: TransactionType) => {
+        setPresetTransaction({ type, date: new Date().toISOString() });
+        setTransactionModalTitle("New " + (type === TransactionType.TRANSFER ? "Transfer" : type.charAt(0) + type.slice(1).toLowerCase()));
+        handleOpenModal('TX_FORM');
+    };
+
     const editingTransaction = useMemo(() => presetTransaction ? presetTransaction as Transaction : data.transactions.find(t => t.id === selectedTxId), [data.transactions, selectedTxId, presetTransaction]);
     const editingWallet = useMemo(() => data.wallets.find(w => w.id === selectedWalletId), [data.wallets, selectedWalletId]);
     const editingBudget = useMemo(() => data.budgets.find(b => b.id === selectedBudgetId), [data.budgets, selectedBudgetId]);
@@ -620,7 +626,7 @@ const App: React.FC = () => {
                 )}
             </div>
 
-            {overlay === 'NONE' && (<BottomNav activeTab={activeTab} onTabChange={handleTabChange} onAddClick={() => { setSelectedTxId(null); setPresetTransaction(undefined); setTransactionModalTitle(undefined); handleOpenModal('TX_FORM'); }} />)}
+            {overlay === 'NONE' && (<BottomNav activeTab={activeTab} onTabChange={handleTabChange} onQuickAdd={handleQuickAdd} onAddClick={() => { setSelectedTxId(null); setPresetTransaction(undefined); setTransactionModalTitle(undefined); handleOpenModal('TX_FORM'); }} />)}
 
             {overlay === 'WALLET_DETAIL' && selectedWalletForDetail && (<WalletDetailView wallet={selectedWalletForDetail} transactions={sortTransactions(data.transactions.filter(t => t.walletId === selectedWalletId || t.transferToWalletId === selectedWalletId))} categories={data.categories} allWallets={data.wallets} commitments={data.commitments} onBack={handleBack} onEdit={() => { handleOpenModal('WALLET_FORM'); }} onTransactionClick={(t) => { setSelectedTxId(t.id); handleOpenModal('TX_FORM'); }} currencySymbol={currentCurrency.symbol} isExiting={isOverlayExiting} />)}
             {overlay === 'BUDGET_DETAIL' && editingBudget && (<BudgetDetailView budget={editingBudget} transactions={sortTransactions(data.transactions.filter(t => t.categoryId === editingBudget.categoryId))} categories={data.categories} wallets={data.wallets} commitments={data.commitments} onBack={handleBack} onEdit={() => { handleOpenModal('BUDGET_FORM'); }} onTransactionClick={(t) => { setSelectedTxId(t.id); handleOpenModal('TX_FORM'); }} currencySymbol={currentCurrency.symbol} isExiting={isOverlayExiting} spending={spendingMap[editingBudget.id] || 0} />)}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,43 +1,104 @@
 
 
-import React from 'react';
-import { Home, Plus, Settings, Sparkle, BarChart3 } from 'lucide-react';
+import React, { useState } from 'react';
+import { Home, Plus, Settings, Sparkle, BarChart3, TrendingUp, TrendingDown, ArrowRightLeft, RefreshCcw } from 'lucide-react';
+import useLongPress from '../hooks/useLongPress';
+import { TransactionType } from '../types';
 
 interface BottomNavProps {
   activeTab: 'HOME' | 'ANALYTICS' | 'COMMITMENTS' | 'SETTINGS';
   onTabChange: (tab: 'HOME' | 'ANALYTICS' | 'COMMITMENTS' | 'SETTINGS') => void;
   onAddClick: () => void;
+  onQuickAdd: (type: TransactionType) => void;
 }
 
-const BottomNav: React.FC<BottomNavProps> = ({ activeTab, onTabChange, onAddClick }) => {
+const BottomNav: React.FC<BottomNavProps> = ({ activeTab, onTabChange, onAddClick, onQuickAdd }) => {
+  const [showQuickMenu, setShowQuickMenu] = useState(false);
+
+  const onLongPress = (e: React.MouseEvent | React.TouchEvent) => {
+    setShowQuickMenu(true);
+  };
+
+  const onClick = () => {
+    onAddClick();
+  };
+
+  const longPressProps = useLongPress(onLongPress, onClick, { delay: 400 });
+
+  const handleQuickOption = (type: TransactionType) => {
+    setShowQuickMenu(false);
+    onQuickAdd(type);
+  }
+
   const getIconClass = (isActive: boolean) =>
     `flex flex-col items-center justify-center w-10 h-10 rounded-2xl transition-all duration-200 ${isActive ? 'text-primary' : 'text-text-secondary hover:text-text-primary hover:bg-surface'}`;
 
   return (
-    <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md px-4">
-        <div className="bg-surface/90 dark:bg-surface/90 backdrop-blur-xl border-t border-white/20 dark:border-white/5 shadow-xl shadow-slate-300/50 dark:shadow-black/50 rounded-3xl py-3 px-6 flex justify-between items-center">
-            
-            <button data-testid="home-button" onClick={() => onTabChange('HOME')} className={getIconClass(activeTab === 'HOME')}>
-                <Home className="w-5 h-5" />
-            </button>
-            
-            <button data-testid="analytics-button" onClick={() => onTabChange('ANALYTICS')} className={getIconClass(activeTab === 'ANALYTICS')}>
-                <BarChart3 className="w-5 h-5" />
-            </button>
-            
-            <button data-testid="add-transaction-button" onClick={onAddClick} className="w-12 h-12 bg-primary rounded-2xl shadow-lg shadow-primary/40 flex items-center justify-center text-white hover:bg-primary-hover transition-transform active:scale-95 mx-2">
-                <Plus className="w-6 h-6" />
-            </button>
-            
-            <button data-testid="commitments-button" onClick={() => onTabChange('COMMITMENTS')} className={getIconClass(activeTab === 'COMMITMENTS')}>
-                <Sparkle className="w-5 h-5" />
-            </button>
-            
-            <button data-testid="settings-button" onClick={() => onTabChange('SETTINGS')} className={getIconClass(activeTab === 'SETTINGS')}>
-                <Settings className="w-5 h-5" />
-            </button>
+    <>
+      {showQuickMenu && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center pb-24 bg-black/20 backdrop-blur-sm animate-in fade-in duration-200" onClick={() => setShowQuickMenu(false)}>
+          <div className="flex flex-col gap-3 items-center mb-2 animate-in slide-in-from-bottom-10 fade-in zoom-in-95 duration-300">
+            <div className="flex gap-4 mb-2">
+              <button onClick={(e) => { e.stopPropagation(); handleQuickOption(TransactionType.INCOME); }} className="flex flex-col items-center gap-1 group">
+                <div className="w-14 h-14 bg-green-500 rounded-full flex items-center justify-center text-white shadow-lg shadow-green-500/30 group-hover:scale-110 transition-transform">
+                  <TrendingUp className="w-6 h-6" />
+                </div>
+                <span className="text-xs font-medium text-white bg-black/50 px-2 py-0.5 rounded-full backdrop-blur-md">Income</span>
+              </button>
+              <button onClick={(e) => { e.stopPropagation(); handleQuickOption(TransactionType.EXPENSE); }} className="flex flex-col items-center gap-1 group">
+                <div className="w-14 h-14 bg-red-500 rounded-full flex items-center justify-center text-white shadow-lg shadow-red-500/30 group-hover:scale-110 transition-transform">
+                  <TrendingDown className="w-6 h-6" />
+                </div>
+                <span className="text-xs font-medium text-white bg-black/50 px-2 py-0.5 rounded-full backdrop-blur-md">Expense</span>
+              </button>
+            </div>
+            <div className="flex gap-4">
+              <button onClick={(e) => { e.stopPropagation(); handleQuickOption(TransactionType.TRANSFER); }} className="flex flex-col items-center gap-1 group">
+                <div className="w-14 h-14 bg-blue-500 rounded-full flex items-center justify-center text-white shadow-lg shadow-blue-500/30 group-hover:scale-110 transition-transform">
+                  <ArrowRightLeft className="w-6 h-6" />
+                </div>
+                <span className="text-xs font-medium text-white bg-black/50 px-2 py-0.5 rounded-full backdrop-blur-md">Transfer</span>
+              </button>
+              <button onClick={(e) => { e.stopPropagation(); handleQuickOption(TransactionType.REFUND); }} className="flex flex-col items-center gap-1 group">
+                <div className="w-14 h-14 bg-purple-500 rounded-full flex items-center justify-center text-white shadow-lg shadow-purple-500/30 group-hover:scale-110 transition-transform">
+                  <RefreshCcw className="w-6 h-6" />
+                </div>
+                <span className="text-xs font-medium text-white bg-black/50 px-2 py-0.5 rounded-full backdrop-blur-md">Refund</span>
+              </button>
+            </div>
+          </div>
         </div>
-    </div>
+      )}
+
+      <div className="fixed bottom-6 left-1/2 transform -translate-x-1/2 z-50 w-full max-w-md px-4">
+        <div className="bg-surface/90 dark:bg-surface/90 backdrop-blur-xl border-t border-white/20 dark:border-white/5 shadow-xl shadow-slate-300/50 dark:shadow-black/50 rounded-3xl py-3 px-6 flex justify-between items-center">
+
+          <button data-testid="home-button" onClick={() => onTabChange('HOME')} className={getIconClass(activeTab === 'HOME')}>
+            <Home className="w-5 h-5" />
+          </button>
+
+          <button data-testid="analytics-button" onClick={() => onTabChange('ANALYTICS')} className={getIconClass(activeTab === 'ANALYTICS')}>
+            <BarChart3 className="w-5 h-5" />
+          </button>
+
+          <button
+            data-testid="add-transaction-button"
+            {...longPressProps}
+            className="w-12 h-12 bg-primary rounded-2xl shadow-lg shadow-primary/40 flex items-center justify-center text-white hover:bg-primary-hover transition-transform active:scale-95 mx-2 cursor-pointer select-none touch-none"
+          >
+            <Plus className={`w-6 h-6 transition-transform duration-300 ${showQuickMenu ? 'rotate-45' : ''}`} />
+          </button>
+
+          <button data-testid="commitments-button" onClick={() => onTabChange('COMMITMENTS')} className={getIconClass(activeTab === 'COMMITMENTS')}>
+            <Sparkle className="w-5 h-5" />
+          </button>
+
+          <button data-testid="settings-button" onClick={() => onTabChange('SETTINGS')} className={getIconClass(activeTab === 'SETTINGS')}>
+            <Settings className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </>
   );
 };
 export default BottomNav;

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,63 @@
+import { useCallback, useRef, useState } from 'react';
+
+interface UseLongPressOptions {
+    shouldPreventDefault?: boolean;
+    delay?: number;
+}
+
+const useLongPress = (
+    onLongPress: (e: React.MouseEvent | React.TouchEvent) => void,
+    onClick: () => void,
+    { shouldPreventDefault = true, delay = 500 }: UseLongPressOptions = {}
+) => {
+    const [longPressTriggered, setLongPressTriggered] = useState(false);
+    const timeout = useRef<NodeJS.Timeout>();
+    const target = useRef<EventTarget>();
+
+    const start = useCallback(
+        (event: React.MouseEvent | React.TouchEvent) => {
+            if (shouldPreventDefault && event.target) {
+                event.target.addEventListener('touchend', preventDefault, { passive: false });
+                target.current = event.target;
+            }
+            timeout.current = setTimeout(() => {
+                onLongPress(event);
+                setLongPressTriggered(true);
+            }, delay);
+        },
+        [onLongPress, delay, shouldPreventDefault]
+    );
+
+    const clear = useCallback(
+        (event?: React.MouseEvent | React.TouchEvent, shouldTriggerClick = true) => {
+            if (timeout.current) {
+                clearTimeout(timeout.current);
+            }
+            if (shouldTriggerClick && !longPressTriggered && onClick) {
+                onClick();
+            }
+            setLongPressTriggered(false);
+            if (shouldPreventDefault && target.current) {
+                target.current.removeEventListener('touchend', preventDefault);
+            }
+        },
+        [shouldPreventDefault, onClick, longPressTriggered]
+    );
+
+    return {
+        onMouseDown: (e: React.MouseEvent) => start(e),
+        onTouchStart: (e: React.TouchEvent) => start(e),
+        onMouseUp: (e: React.MouseEvent) => clear(e),
+        onMouseLeave: (e: React.MouseEvent) => clear(e, false),
+        onTouchEnd: (e: React.TouchEvent) => clear(e),
+    };
+};
+
+const preventDefault = (e: Event) => {
+    if (!('touches' in e)) return;
+    if ((e as unknown as TouchEvent).touches.length < 2 && e.preventDefault) {
+        e.preventDefault();
+    }
+};
+
+export default useLongPress;


### PR DESCRIPTION
Implemented Long Press Quick Menu on FAB.\n\nCloses #239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added quick-add transaction menu: long-press the add button to quickly create a transaction with a preset type (Income, Expense, Transfer, or Refund), streamlining frequent transaction entries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->